### PR TITLE
CRAB-44859: Do multi-platform builds.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 image_name="seeq13/pr-reminders"
-docker build --tag "$image_name":latest .
+docker build --platform=linux/amd64,linux/arm64 --tag "$image_name":latest .
 if [[ $# -eq 1 ]]; then
     version="$1"
     docker tag "$image_name":latest "$image_name":"$version"


### PR DESCRIPTION
We realized that all the images I had built were arm64 and all the images @mar1u50 built had done were amd64. Oops. This should fix that for future builds.