### PR TITLE
Reduce spam of Review Requests & Zero Reviews (issue#18)

### DIFF
--- a/pr-reminders/main.py
+++ b/pr-reminders/main.py
@@ -38,9 +38,9 @@ def main():
     )
     sorted_prs = sorted(_no_drafts(prs), key=lambda pr: pr.updated_at)
     reminders = [
-        _needs_review_reminder(sorted_prs),
+        _needs_review_reminder(now, sorted_prs),
         _sleeping_reminder(now, sorted_prs),
-        _no_primary_reminder(sorted_prs)
+        _no_primary_reminder(now, sorted_prs)
     ]
 
     slackbot = slack.Bot(env.slack_access_token)
@@ -50,10 +50,10 @@ def main():
                          reminder['header'])
 
 
-def _needs_review_reminder(prs: List[github_api.PrData]) -> PrReminder:
+def _needs_review_reminder(now: datetime, prs: List[github_api.PrData]) -> PrReminder:
     prs_needing_review = [
         pr for pr in prs
-        if pr.review_requests_count > 0 and pr.reviews_count == 0
+        if pr.review_requests_count > 0 and pr.reviews_count == 0 and pr.updated_at < now - timedelta(hours=8)
     ]
     message = 'The following PRs have review requests and zero reviews - please take a look!' \
         if len(prs_needing_review) > 0 \
@@ -80,9 +80,9 @@ def _sleeping_reminder(now: datetime, prs: List[github_api.PrData]) -> PrReminde
     }
 
 
-def _no_primary_reminder(prs: List[github_api.PrData]) -> PrReminder:
+def _no_primary_reminder(now: datetime, prs: List[github_api.PrData]) -> PrReminder:
     prs_without_primary = [
-        pr for pr in prs if _no_primary(pr)
+        pr for pr in prs if _no_primary(pr) and pr.updated_at < now - timedelta(hours=8)
     ]
     message = 'The following PRs have have no primary reviewer - please take a look!' \
         if len(prs_without_primary) > 0 \


### PR DESCRIPTION
This PR updates the PRs with Review Requests & Zero Reviews to ping only if it’s been waiting for more than 8 hours
This will make the notification more actionable, and we can use as more of a strict “exception” list (i.e. a PR is falling outside of our expectations, we should look at it)

https://github.com/seeq12/pr-reminders/issues/18